### PR TITLE
Add simple portfolio boilerplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+.env.*.local

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Portfolio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body class="font-inter">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "portfolio",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.3.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,21 @@
+import NavBar from "./components/NavBar";
+import Hero from "./components/Hero";
+import Profile from "./components/Profile";
+import Skills from "./components/Skills";
+import Projects from "./components/Projects";
+import Contact from "./components/Contact";
+
+function App() {
+  return (
+    <div>
+      <NavBar />
+      <Hero />
+      <Profile />
+      <Skills />
+      <Projects />
+      <Contact />
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,0 +1,17 @@
+const Contact = () => {
+  return (
+    <section id="contact" className="bg-gray-50 py-16">
+      <div className="max-w-4xl mx-auto px-4 text-center">
+        <h2 className="text-3xl font-bold mb-4">Contact</h2>
+        <p>
+          Feel free to reach out via{" "}
+          <a className="text-blue-500 underline" href="mailto:your@email.com">
+            email
+          </a>
+        </p>
+      </div>
+    </section>
+  );
+};
+
+export default Contact;

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,13 @@
+const Hero = () => {
+  return (
+    <section
+      id="hero"
+      className="h-screen bg-gradient-to-br from-indigo-500 to-purple-600 flex flex-col justify-center items-center text-white"
+    >
+      <h1 className="text-4xl md:text-6xl font-bold mb-4">Your Name</h1>
+      <p className="text-xl md:text-2xl">Welcome to my portfolio</p>
+    </section>
+  );
+};
+
+export default Hero;

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+
+const NavBar = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const toggle = () => setIsOpen(!isOpen);
+
+  const navItems = [
+    { id: "hero", label: "Home" },
+    { id: "profile", label: "Profile" },
+    { id: "skills", label: "Skills" },
+    { id: "projects", label: "Projects" },
+    { id: "contact", label: "Contact" },
+  ];
+
+  const linkClasses = "block px-4 py-2 hover:text-blue-500";
+
+  return (
+    <nav className="fixed w-full bg-white shadow z-10">
+      <div className="max-w-4xl mx-auto px-4 py-2 flex items-center justify-between">
+        <div className="text-xl font-bold">My Portfolio</div>
+        <div className="md:hidden">
+          <button onClick={toggle} className="p-2">
+            <span className="sr-only">Open Menu</span>
+            <svg
+              className="w-6 h-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              {isOpen ? (
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              ) : (
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 6h16M4 12h16M4 18h16"
+                />
+              )}
+            </svg>
+          </button>
+        </div>
+        <div className="hidden md:flex space-x-4">
+          {navItems.map((item) => (
+            <a key={item.id} href={`#${item.id}`} className={linkClasses}>
+              {item.label}
+            </a>
+          ))}
+        </div>
+      </div>
+      {isOpen && (
+        <div className="md:hidden px-4 pb-4">
+          {navItems.map((item) => (
+            <a
+              key={item.id}
+              href={`#${item.id}`}
+              className={linkClasses}
+              onClick={() => setIsOpen(false)}
+            >
+              {item.label}
+            </a>
+          ))}
+        </div>
+      )}
+    </nav>
+  );
+};
+
+export default NavBar;

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -1,0 +1,18 @@
+const Profile = () => {
+  return (
+    <section id="profile" className="max-w-4xl mx-auto py-16 px-4 text-center">
+      <h2 className="text-3xl font-bold mb-4">Profile</h2>
+      <img
+        className="w-32 h-32 rounded-full mx-auto mb-4"
+        src="https://via.placeholder.com/150"
+        alt="Profile"
+      />
+      <p>
+        Short bio goes here. I'm a software developer specializing in web
+        technologies.
+      </p>
+    </section>
+  );
+};
+
+export default Profile;

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,0 +1,36 @@
+const projects = [
+  {
+    name: "Project One",
+    description: "Description of project one.",
+    url: "#",
+  },
+  {
+    name: "Project Two",
+    description: "Description of project two.",
+    url: "#",
+  },
+];
+
+const Projects = () => {
+  return (
+    <section id="projects" className="py-16">
+      <div className="max-w-4xl mx-auto px-4">
+        <h2 className="text-3xl font-bold mb-4 text-center">Projects</h2>
+        <div className="grid md:grid-cols-2 gap-4">
+          {projects.map((project) => (
+            <a
+              key={project.name}
+              href={project.url}
+              className="block border rounded p-4 hover:shadow"
+            >
+              <h3 className="text-xl font-semibold">{project.name}</h3>
+              <p className="text-gray-600">{project.description}</p>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Projects;

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,0 +1,20 @@
+const skills = ["React", "TypeScript", "Rails", "Tailwind CSS"];
+
+const Skills = () => {
+  return (
+    <section id="skills" className="bg-gray-50 py-16">
+      <div className="max-w-4xl mx-auto px-4">
+        <h2 className="text-3xl font-bold mb-4 text-center">Skills</h2>
+        <ul className="flex flex-wrap justify-center gap-4">
+          {skills.map((skill) => (
+            <li key={skill} className="bg-white shadow px-4 py-2 rounded">
+              {skill}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default Skills;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+  content: [
+    "./index.html",
+    "./src/**/*.{ts,tsx}",
+  ],
+  theme: {
+    extend: {},
+    fontFamily: {
+      inter: ["Inter", "sans-serif"],
+    },
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- initialize a Vite + React + TypeScript project
- set up Tailwind CSS with Inter font
- implement basic portfolio sections and navigation

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6846bed33f188330ac787c7b13de2cd1