### PR TITLE
Update deploy-pages action to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,4 +48,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- update `actions/deploy-pages` from v3 to v4

Node 16 has reached end-of-life and GitHub recommends moving to the latest major actions. The new version improves security and reliability of deployments.

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847638c4f408330b01638e96743b3f8