### PR TITLE
Add Gaooh profile page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ Here are some ideas to get you started:
 - ⚡ Fun fact: ...
 -->
 # Rebuild trigger
+
+This repository now includes a profile page for **gaooh** available at
+`/gaooh.html` when running the site locally or after building. The page
+introduces gaooh as a software engineer who loves cats, lions, beer and
+road bikes, and provides links to various social profiles.

--- a/gaooh.html
+++ b/gaooh.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>gaooh Profile</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  </head>
+  <body class="font-inter">
+    <div id="root"></div>
+    <script type="module" src="/src/gaooh.tsx"></script>
+  </body>
+</html>

--- a/src/components/GaoohProfile.tsx
+++ b/src/components/GaoohProfile.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+const GaoohProfile = () => {
+  return (
+    <div className="max-w-xl mx-auto my-8 p-4 text-gray-800">
+      <h1 className="text-4xl font-bold mb-4 text-center">gaooh</h1>
+      <p className="mb-6 text-center">
+        ソフトウェアエンジニア。猫とライオンをこよなく愛し、ビールを片手にロードバイクで走ることが好きです。
+      </p>
+      <ul className="space-y-2">
+        <li>
+          <a className="text-blue-500 underline" href="https://gaooh.hatenablog.com/">Blog</a>
+        </li>
+        <li>
+          <a className="text-blue-500 underline" href="https://x.com/gaooh">X (Twitter)</a>
+        </li>
+        <li>
+          <a className="text-blue-500 underline" href="https://www.instagram.com/gaooh/">Instagram</a>
+        </li>
+        <li>
+          <a className="text-blue-500 underline" href="https://www.facebook.com/akiko.asami">Facebook</a>
+        </li>
+        <li>
+          <a className="text-blue-500 underline" href="https://www.wantedly.com/id/gaooh">Wantedly</a>
+        </li>
+        <li>
+          <a className="text-blue-500 underline" href="https://www.strava.com/athletes/89243892">Strava</a>
+        </li>
+      </ul>
+    </div>
+  );
+};
+
+export default GaoohProfile;

--- a/src/gaooh.tsx
+++ b/src/gaooh.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import GaoohProfile from "./components/GaoohProfile";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <GaoohProfile />
+  </React.StrictMode>
+);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,16 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { resolve } from "path";
 
 export default defineConfig({
   plugins: [react()],
   base: '/',
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        gaooh: resolve(__dirname, 'gaooh.html'),
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- create `GaoohProfile` React component with bio and links
- add `gaooh.tsx` entrypoint and `gaooh.html` page
- enable multi page build in `vite.config.ts`
- update README with info about the new page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68526bf9ec8c83309062049549964337